### PR TITLE
New state-parquet script with year_var 

### DIFF
--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -11,13 +11,14 @@ on:
 name: run_workflow.yml
 
 jobs:
-  states:
+
+  small_states:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         # state: ["DE", "RI"]
-        state: ["AL", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
+        state: ["AZ", "AR", "CA", "CO", "CT", "DE", "FL", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "ND", "OH", "OK", "PA", "RI", "SC", "SD", "TN", "UT", "VT", "VA", "WA", "WV", "WY"]
     steps:
       - uses: actions/checkout@v4
       
@@ -44,12 +45,46 @@ jobs:
         with:
           name: ${{ matrix.state }}
           path: fia/parquet/*
+          
+  large_states:
+    runs-on: BigStateRunner # Update this with actual name
+    strategy:
+      fail-fast: false
+      matrix:
+        state: ["AL", "GA", "MI", "MN", "NC", "OR", "TX", "WI"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::dplyr
+            any::purrr
+            any::nanoparquet
+            any::fs
+            github::Evans-Ecology-Lab/forestTIME
+
+      - name: Generate state parquet
+        run: Rscript state-parquet.R
+        env:
+          STATE: ${{ matrix.state }}
+          
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.state }}
+          path: fia/parquet/*
 
   release:
   # only happens if schedule or workflow_dispatch with release=TRUE
     if: ${{ (inputs.release && github.event_name == 'workflow_dispatch') || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
-    needs: states
+    needs: [small_states, large_states]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -11,69 +11,26 @@ on:
 name: run_workflow.yml
 
 jobs:
-
-  small_states:
-    runs-on: ubuntu-latest
+  states:
+    timeout-minutes: 2160
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
-        # state: ["DE", "RI"]
-        state: ["AZ", "AR", "CA", "CO", "CT", "DE", "FL", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "ND", "OH", "OK", "PA", "RI", "SC", "SD", "TN", "UT", "VT", "VA", "WA", "WV", "WY"]
+        state: ["GA", "MI",]
+      # state: ["AL", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
+    container:
+      image: ghcr.io/devinbayly/foresttime-hpc:latest
     steps:
+      - name: install forestTIME
+        run: R -e "pak::pak('Evans-Ecology-Lab/forestTIME')"
       - uses: actions/checkout@v4
-      
-      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          packages: |
-            any::dplyr
-            any::purrr
-            any::nanoparquet
-            any::fs
-            github::Evans-Ecology-Lab/forestTIME
-      
+         path: ${{ github.sha }}
       - name: Generate state parquet
         run: Rscript state-parquet.R
         env:
           STATE: ${{ matrix.state }}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.state }}
-          path: fia/parquet/*
-          
-  large_states:
-    runs-on: BigStateRunner # Update this with actual name
-    strategy:
-      fail-fast: false
-      matrix:
-        state: ["AL", "GA", "MI", "MN", "NC", "OR", "TX", "WI"]
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: 'release'
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          packages: |
-            any::dplyr
-            any::purrr
-            any::nanoparquet
-            any::fs
-            github::Evans-Ecology-Lab/forestTIME
-
-      - name: Generate state parquet
-        run: Rscript state-parquet.R
-        env:
-          STATE: ${{ matrix.state }}
-          
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -84,7 +41,7 @@ jobs:
   # only happens if schedule or workflow_dispatch with release=TRUE
     if: ${{ (inputs.release && github.event_name == 'workflow_dispatch') || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
-    needs: [small_states, large_states]
+    needs: states
     steps:
       - uses: actions/checkout@v4
 
@@ -108,8 +65,10 @@ jobs:
             any::httr2
             any::purrr
             any::fs
+            any::jsonlite
 
       - name: Create new version and upload to Zenodo
         run: Rscript zenodo-api.R
         env:
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+ 

--- a/state-parquet-v2.R
+++ b/state-parquet-v2.R
@@ -1,0 +1,123 @@
+state = Sys.getenv("STATE", unset = "RI") #use RI for testing because it is small
+
+library(forestTIME)
+library(dplyr)
+library(purrr)
+library(nanoparquet)
+library(fs)
+
+# Data Download
+fia_download(states = state, keep_zip = FALSE)
+
+# Data prep
+db <- fia_load(states = state)
+data <- fia_tidy(db)
+
+# Run workflow twice: once for MEASYEAR, once for INVYR
+for (year_var in c("INVYR", "MEASYEAR")) {
+  
+  message("Running workflow with year_var = ", year_var)
+  
+  # Expand to include all years between surveys and interpolate/extrapolate
+  data_interpolated <- data |>
+    expand_data(year_var = year_var) |>
+    interpolate_data()
+  
+  # Adjust for mortality and estimate carbon.
+  # If any trees use the `MORTYR` variable, use both methods for adjusting for mortality
+  do_both <- any(!is.na(data$MORTYR))
+  rm(data) # to save memory
+  gc()
+  
+  if (do_both) {
+    data_mortyr <-
+      data_interpolated |>
+      adjust_mortality(use_mortyr = TRUE)
+  }
+  
+  data_midpt <-
+    data_interpolated |>
+    adjust_mortality(use_mortyr = FALSE)
+  
+  rm(data_interpolated) # to save memory
+  gc()
+  fs::dir_create("fia/parquet")
+  
+  max_rows <- 5e5 # do carbon estimation in chunks if more than this many rows
+  if (nrow(data_midpt) <= max_rows) {
+    if (do_both) {
+      data_mortyr <- data_mortyr |>
+        fia_allometry() |>
+        fia_design(db) |>
+        fia_split_composite_ids()
+      
+      nanoparquet::write_parquet(
+        data_mortyr,
+        file = glue::glue("fia/parquet/{state}_mortyr_{year_var}.parquet"),
+        compression = "zstd",
+        options = parquet_options(compression_level = 19)
+      )
+      rm(data_mortyr)
+      gc()
+    }
+    
+    data_midpt <- data_midpt |>
+      fia_allometry() |>
+      fia_design(db) |>
+      fia_split_composite_ids()
+    
+    # Write out to parquet
+    message("writing midpt to parquet")
+    nanoparquet::write_parquet(
+      data_midpt,
+      glue::glue("fia/parquet/{state}_midpt_{year_var}.parquet"),
+      compression = "zstd",
+      options = parquet_options(compression_level = 19)
+    )
+  } else {
+    # chunk into a list of data frames with at most `max_rows` rows
+    n_groups <- ceiling(nrow(data_midpt) / max_rows)
+    
+    # Arranging by split ID components and YEAR shrinks file size for parquet
+    if (do_both) {
+      data_mortyr <- data_mortyr |>
+        mutate(cut_group = cut(1:n(), n_groups)) |>
+        group_by(cut_group) |>
+        group_split() |>
+        map(fia_allometry) |>
+        list_rbind() |>
+        fia_design(db) |>
+        fia_split_composite_ids() |>
+        arrange(STATECD, UNITCD, COUNTYCD, PLOT, SUBP, TREE, YEAR)
+      
+      message("writing mortyr to parquet")
+      nanoparquet::write_parquet(
+        data_mortyr,
+        file = glue::glue("fia/parquet/{state}_mortyr_{year_var}.parquet"),
+        compression = "zstd",
+        options = parquet_options(compression_level = 19)
+      )
+      rm(data_mortyr)
+      gc()
+    }
+    
+    data_midpt <- data_midpt |>
+      mutate(cut_group = cut(1:n(), n_groups)) |>
+      group_by(cut_group) |>
+      group_split() |>
+      map(fia_allometry) |>
+      list_rbind() |>
+      fia_design(db) |>
+      fia_split_composite_ids() |>
+      arrange(STATECD, UNITCD, COUNTYCD, PLOT, SUBP, TREE, YEAR)
+    
+    # Write out to parquet
+    message("writing midpt to parquet")
+    nanoparquet::write_parquet(
+      data_midpt,
+      glue::glue("fia/parquet/{state}_midpt_{year_var}.parquet"),
+      compression = "zstd",
+      options = parquet_options(compression_level = 19)
+    )
+  }
+}


### PR DESCRIPTION
This new state-parquet v2 script includes the year_var argument in expand_data which allows expansion/interpolation to happen based on inventory year (INVYR) or measurement year(MEASYEAR). I've written it as a for loop so that it will run the workflow for both year variable types. The output should be four parquet files "_midpt_INVYR", "_midpt_MEASYEAR", "mortyr_INVYR", and "mortyr_MEASYEAR". This will increase the run time for each state. If it increases significantly then we will explore running the INVYR and MEASYEAR workflows in parallel. 