### PR TITLE
V2 missing devin

### DIFF
--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -27,8 +27,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
          ref: ${{ github.event.pull_request.head.sha }}
-      - name: see git log info
-        run: git -P log
       - name: check directory contents
         run: ls -rtlha
       - name: Generate state parquet

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -26,7 +26,9 @@ jobs:
         run: R -e "pak::pak('Evans-Ecology-Lab/forestTIME#231')"
       - uses: actions/checkout@v4
         with:
-         path: ${{ github.sha }}
+         ref: ${{ github.event.pull_request.head.sha }}
+      - name: see git log info
+        run: git -P log
       - name: check directory contents
         run: ls -rtlha
       - name: Generate state parquet

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -23,8 +23,6 @@ jobs:
       image: ghcr.io/devinbayly/foresttime-hpc:latest
     steps:
       - uses: actions/checkout@v4
-        with:
-         ref: ${{ github.event.pull_request.head.sha }}
       - name: check directory contents
         run: ls -rtlha
       - name: install forestTIME

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -22,8 +22,8 @@ jobs:
     container:
       image: ghcr.io/devinbayly/foresttime-hpc:latest
     steps:
-      - name: install forestTIME
-        run: R -e "pak::pak('Evans-Ecology-Lab/forestTIME#231')"
+      # - name: install forestTIME
+      #   run: R -e "pak::pak('Evans-Ecology-Lab/forestTIME#231')"
       - uses: actions/checkout@v4
         with:
          ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -22,13 +22,13 @@ jobs:
     container:
       image: ghcr.io/devinbayly/foresttime-hpc:latest
     steps:
-      # - name: install forestTIME
-      #   run: R -e "pak::pak('Evans-Ecology-Lab/forestTIME#231')"
       - uses: actions/checkout@v4
         with:
          ref: ${{ github.event.pull_request.head.sha }}
       - name: check directory contents
         run: ls -rtlha
+      - name: install forestTIME
+        run: R -e "pak::pak('Evans-Ecology-Lab/forestTIME#231')"
       - name: Generate state parquet
         run: Rscript state-parquet-v2.R
         env:

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
          path: ${{ github.sha }}
+      - name: check directory contents
+        run: ls -rtlha
       - name: Generate state parquet
         run: Rscript state-parquet-v2.R
         env:


### PR DESCRIPTION
Hey there

Pretty sure the issue was the checkout action was putting it's copy of the repo into a location specified with the sha of the commit (long unique id)

uses: actions/checkout@v4
        with:
         path: ${{ github.sha }}

so I removed that part and just went to see if it works on its own and it seems ok with just this line. 

uses: actions/checkout@v4